### PR TITLE
Fix "Use `is` or `is not` to compare with `None`" issue

### DIFF
--- a/bin/core.py
+++ b/bin/core.py
@@ -41,7 +41,7 @@ class core(object):
 
         response_list = list()
 
-        if expert_advice == None:
+        if expert_advice is None:
             response_list.append('Hi ! Please click the button below to begin ! ')
             response_dict['response_list'] = response_list
             response_dict['keyboard'] = create_keyboard(['Begin consultation with Doctor SkyNet'])

--- a/expert_system/DoctorSkyNet.py
+++ b/expert_system/DoctorSkyNet.py
@@ -89,7 +89,7 @@ class DoctorSkyNet(object):
 
     def check_if_top_asked(self, question):
         # first check if the question is a top question
-        if question == None:
+        if question is None:
             print "none in invalid"
             return None
         if question in self.question_structure_dict.keys():
@@ -140,28 +140,28 @@ class DoctorSkyNet(object):
         '''
         if (self.fraction < self.change_point_one):
             self.ask_this = self.algorithm_one()
-            if self.ask_this == None:
+            if self.ask_this is None:
                 self.ask_this = self.algorithm_two()
 
-                if self.ask_this == None:
+                if self.ask_this is None:
                     self.ask_this = self.algorithm_three()
-                    if self.ask_this == None:
+                    if self.ask_this is None:
                         self.done = 1
 
         elif self.fraction < self.change_point_two:
             self.ask_this = self.algorithm_two()
-            if self.ask_this == None:
+            if self.ask_this is None:
                 self.ask_this = self.algorithm_three()
         else:
             self.ask_this = self.algorithm_three()
-            if self.ask_this == None:
+            if self.ask_this is None:
                 self.done = 1
                 # SEND MAIL HERE
                 # print "None caught in 33"
 
         if self.done == 0:
             q = self.check_if_top_asked(self.ask_this)
-            if q == None:
+            if q is None:
                 # print "None captured in 3"
                 return self.create_question(self.ask_this)
             else:
@@ -177,7 +177,7 @@ class DoctorSkyNet(object):
         question = self.bucket_object.get_popular_symptoms()
         print bcolors.WARNING + "using algo-1-"
         print bcolors.OKBLUE
-        if question == None:
+        if question is None:
             print "None in algo one:"
             return None
         return question
@@ -189,7 +189,7 @@ class DoctorSkyNet(object):
         question = self.bucket_object.get_top_critical_symptoms()
         print bcolors.WARNING + "Using algo-2-"
         print bcolors.OKBLUE
-        if question == None:
+        if question is None:
             print "None in algo two"
             return None
         return question
@@ -201,7 +201,7 @@ class DoctorSkyNet(object):
         question = self.bucket_object.get_buckets_top_symptom()
         print bcolors.WARNING + "using algo-3-"
         print bcolors.OKBLUE
-        if question == None:
+        if question is None:
             print "None in algo three"
             self.done = 1
             return None
@@ -282,14 +282,14 @@ class DoctorSkyNet(object):
     invalidates the linked question if top question is false
     """
     def invalidate_question(self, question):
-        if question == None:
+        if question is None:
             return None
         if question in self.question_structure_dict.keys():
             lista = self.question_structure_dict[question]
 
             if len(lista) > 0:
                 for questions in lista:
-                    if questions == None:
+                    if questions is None:
                         pass
                     #print question + " invalidated" + " for response " + self.response
                     self.bucket_object.answered_question_True(question, False, None, None)
@@ -302,7 +302,7 @@ class DoctorSkyNet(object):
                 self.last_asked_basic_question = tag
                 break
 
-        if next_question == None:
+        if next_question is None:
             return None
 
         question_dict = __import__('basic_data').data()[next_question]
@@ -314,7 +314,7 @@ class DoctorSkyNet(object):
         return q_obj
 
     def askdoctor(self, response=None):
-        if response != None:
+        if response is not None:
             self.response = response
         self.update_fractions()
         self.stage_1 = 1 # state just for future proofing. No use right now.
@@ -326,7 +326,7 @@ class DoctorSkyNet(object):
                 self.basic_data_questions_table[self.last_asked_basic_question] = self.response
 
             q_obj = self.next_basic_data_question()
-            if q_obj == None:
+            if q_obj is None:
                 self.stage_0 = 1
                 self.response = None
 
@@ -343,12 +343,12 @@ class DoctorSkyNet(object):
             print "DONE"
             return None
         elif self.stage_1 == 1 and self.stage_0 == 1 and self.done == 0:
-            if self.last_asked_question == None and self.response == None:
+            if self.last_asked_question is None and self.response is None:
                 q_obj = self.next_question()
             else:
                 self.send_last_question_details()
                 q_obj = self.next_question()
-            if q_obj == None:
+            if q_obj is None:
                 self.done = 1
                 print "All Questions done!"
                 self.sendMail()

--- a/expert_system/disease_interface.py
+++ b/expert_system/disease_interface.py
@@ -274,7 +274,7 @@ class Buckets:
     def calculate_highest_symptom(self):
         for disease_name in self.bucket:
             symptom = self.get_highest_symptom(disease_name)
-            if symptom == None:
+            if symptom is None:
                 pass
             else:
 
@@ -364,7 +364,7 @@ class Buckets:
     '''
 
     def remove_symptom_score(self,symptom,disease_dict):
-        if disease_dict[symptom] == None : 
+        if disease_dict[symptom] is None : 
             print "symptom already asked , hence ignore"
         elif symptom == 'name':
             pass

--- a/expert_system/expert_system.py
+++ b/expert_system/expert_system.py
@@ -43,7 +43,7 @@ class expert_system:
 
         if self.status == 2: # in stage 2 last response from user is passed to AI 
             q_obj = self.AI.askdoctor(user_response)
-            if q_obj == None:
+            if q_obj is None:
                 self.status = 3
                 returns = dict()
                 returns['text'] = 'Your Test is Complete, Please tell the doctor your ID:' + str(self.chat_id)

--- a/expert_system/expert_system_helper.py
+++ b/expert_system/expert_system_helper.py
@@ -85,17 +85,17 @@ class question_interface_helper():
         linked_questions_list = []
         data = __import__(symptom_tag).data()
 
-        if serial == None and linked_question_tag == None:
+        if serial is None and linked_question_tag is None:
             for tag, value in data.iteritems():
                 linked_questions_list.append(self._build_linked_list(value, tag))
 
             linked_questions_list.sort(key=lambda x: x.serial)
-        elif serial == None and linked_question_tag:  # search and load linked question by tag
+        elif serial is None and linked_question_tag:  # search and load linked question by tag
             for tag, value in data.iteritems():
                 if tag == linked_question_tag:
                     linked_questions_list.append(self._build_linked_list(value, tag))
 
-        elif linked_question_tag == None and serial:  # search by serial
+        elif linked_question_tag is None and serial:  # search by serial
             for tag, value in data.iteritems():
                 if value['serial'] == serial:
                     linked_questions_list.append(self._build_linked_list(value, tag))

--- a/expert_system/scratch_pad.py
+++ b/expert_system/scratch_pad.py
@@ -154,7 +154,7 @@ if __name__ == '__main__':
     if sp.query('fever') == ['fever_measure', 'fever_periodic']:
         print "PASS2"
 
-    if sp.query('fever', True) == None:
+    if sp.query('fever', True) is None:
         print "PASS3"
 
     sp.set_top_level('fever')
@@ -162,7 +162,7 @@ if __name__ == '__main__':
         print "PASS4"
 
     sp.pop('fever')
-    if sp.query('fever_measure') == True and sp.query('fever_periodic') == None \
+    if sp.query('fever_measure') == True and sp.query('fever_periodic') is None \
     and sp.query('fever') == ['fever_periodic']:
         print "PASS5"
 

--- a/expert_system/symptom_validity_table.py
+++ b/expert_system/symptom_validity_table.py
@@ -69,7 +69,7 @@ class symptom_validity_table(object):
         tags = list()
 
         for tag in d:
-            if not (self.data[tag] == None and d[tag] == None):
+            if not (self.data[tag] is None and d[tag] is None):
                 tags.append(tag)
 
         return tags


### PR DESCRIPTION
This pull request automatically fixes all occurrences of the following issue:

Issue type: [Use `is` or `is not` to compare with `None`](https://www.quantifiedcode.com/app/issue_class/3IY8CZ0v)
Issue details: [https://www.quantifiedcode.com/app/project/gh:jaideepkekre:MediBot?groups=code_patterns/%3A3IY8CZ0v](https://www.quantifiedcode.com/app/project/gh:jaideepkekre:MediBot?groups=code_patterns/%3A3IY8CZ0v)

To adjust the commit message or the actual code changes, just [rebase](https://git-scm.com/docs/git-rebase) or [cherry-pick](https://git-scm.com/docs/git-cherry-pick) the commits.
For questions or feedback reach out to cody@quantifiedcode.com.

Legal note: We won't claim any copyrights on the code changes.

Cheers,
[Cody - Your code quality bot](https://www.quantifiedcode.com/cody)
